### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -16,9 +16,9 @@ BareBoneSim800	KEYWORD1
 
 # Methods for Sleep (KEYWORD2)
 #######################################
-setFullMode KEYWORD2
-enterSleepMode KEYWORD2
-disableSleep KEYWORD2
+setFullMode	KEYWORD2
+enterSleepMode	KEYWORD2
+disableSleep	KEYWORD2
 
 
 # Methods for SMS (KEYWORD2)
@@ -30,16 +30,16 @@ readSMS	KEYWORD2
 # Methods for INTERNET (KEYWORD2)
 #######################################
 gprsConnect	KEYWORD2
-gprsDisconnect KEYWORD2
-sendHTTPData KEYWORD2
+gprsDisconnect	KEYWORD2
+sendHTTPData	KEYWORD2
 closeHTTP	KEYWORD2
 
 
 # Methods for Module (KEYWORD2)
 #######################################
-begin KEYWORD2 
-isAttached KEYWORD2
+begin	KEYWORD2 
+isAttached	KEYWORD2
 getTime	KEYWORD2
-getLocation KEYWORD2
-getBattPercent KEYWORD2
+getLocation	KEYWORD2
+getBattPercent	KEYWORD2
 flushSerial	KEYWORD2


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords